### PR TITLE
Added range values to the RangeSliderThumbShape.paint method

### DIFF
--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -1,4 +1,3 @@
-
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -1,3 +1,4 @@
+
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
@@ -1435,6 +1436,7 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       sliderTheme: _sliderTheme,
       thumb: bottomThumb,
       isPressed: bottomThumb == Thumb.start ? startThumbSelected : endThumbSelected,
+      values: _values,
     );
 
     if (shouldPaintValueIndicators) {
@@ -1511,6 +1513,7 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       sliderTheme: _sliderTheme,
       thumb: topThumb,
       isPressed: topThumb == Thumb.start ? startThumbSelected : endThumbSelected,
+      values: _values,
     );
   }
 

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -1148,6 +1148,7 @@ abstract class RangeSliderThumbShape {
     SliderThemeData sliderTheme,
     Thumb thumb,
     bool isPressed,
+    RangeValues values
   });
 }
 
@@ -2406,6 +2407,7 @@ class RoundRangeSliderThumbShape extends RangeSliderThumbShape {
     TextDirection textDirection,
     Thumb thumb,
     bool isPressed,
+    RangeValues values
   }) {
     assert(context != null);
     assert(center != null);


### PR DESCRIPTION
## Description

This PR just provide the range values to the `RangeSliderThumbShape.paint` method so that one that implements it can easily receive updated values about the range slider thumbs value.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/62486

## Tests

This doesn't require tests since those are small changes. Please let me know if you disagree.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.