### PR TITLE
Clarified '/' route in initialRoute docs

### DIFF
--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -528,11 +528,15 @@ class WidgetsApp extends StatefulWidget {
   /// Defaults to [Window.defaultRouteName], which may be overridden by the code
   /// that launched the application.
   ///
-  /// If the route name starts with a slash and has multiple slashes in it, then
-  /// it is treated as a "deep link", and before this route is pushed, the
-  /// routes leading to this one are pushed also. For example, if the route was
-  /// `/a/b/c`, then the app would start with the three routes `/a`, `/a/b`, and
-  /// `/a/b/c` loaded, in that order.
+  /// If the route name starts with a slash, then it is treated as a "deep link",
+  /// and before this route is pushed, the routes leading to this one are pushed
+  /// also. For example, if the route was `/a/b/c`, then the app would start
+  /// with the four routes `/`, `/a`, `/a/b`, and `/a/b/c` loaded, in that order.
+  ///
+  /// Even if the route was just `/a`, the app would start with `/` and `/a`
+  /// loaded. This is why it is preferable to avoid hardcoding a deep link
+  /// [initialRoute] to simply set the default route of the app. The [home]
+  /// property is better suited for this.
   ///
   /// Intermediate routes aren't required to exist. In the example above, `/a`
   /// and `/a/b` could be skipped if they have no matching route. But `/a/b/c` is


### PR DESCRIPTION
## Description

This PR clarifies the fact that Navigator will always load the `/` route as the root of [initialRoute](https://master-api.flutter.dev/flutter/material/MaterialApp/initialRoute.html) deep links and that even simple routes like `/a` will be treated as deep links (this would mean two routes are pushed). This is to deter new users from trying to use this property when they could just use `home` or `routes: { '/': (context) =>...` instead. The resulting confusion can be seen in the linked issue.

## Related Issues

64775

## Tests

Not necessary, this is a documentation PR.

## Checklist

Before you create this PR, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze --flutter-repo`) does not report any problems on my PR.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [Handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Test Coverage]: https://github.com/flutter/flutter/wiki/Test-coverage-for-package%3Aflutter
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
