### PR TITLE
remove trailing space.

### DIFF
--- a/packages/flutter_driver/lib/src/driver/driver.dart
+++ b/packages/flutter_driver/lib/src/driver/driver.dart
@@ -199,7 +199,6 @@ abstract class FlutterDriver {
   Future<void> waitFor(SerializableFinder finder, { Duration timeout }) async {
     await sendCommand(WaitFor(finder, timeout: timeout));
   }
-  
   /// Waits until [finder] can no longer locate the target.
   Future<void> waitForAbsent(SerializableFinder finder, { Duration timeout }) async {
     await sendCommand(WaitForAbsent(finder, timeout: timeout));


### PR DESCRIPTION
remove trailing space that was causing analyzer to fail.
